### PR TITLE
Add minimal ListSets support

### DIFF
--- a/Classes/Server.php
+++ b/Classes/Server.php
@@ -47,6 +47,7 @@ class Server {
         $this->args = $args;
         $this->identifyResponse = $identifyResponse;
         $this->listMetadataFormatsCallback = $callbacks['ListMetadataFormats'];
+        $this->listSetsCallback = $callbacks['ListSets'];
         $this->listRecordsCallback = $callbacks['ListRecords'];
         $this->getRecordCallback = $callbacks['GetRecord'];
         $this->max_records = $config['maxRecords'];
@@ -115,6 +116,20 @@ class Server {
             } else {
                 $this->errors[] = new Exception('badResumptionToken');
             }
+        } elseif (empty($this->errors)) {
+            try {
+                if ($sets = call_user_func($this->listSetsCallback, $identifier)) {
+                    foreach ($sets as $key => $val) {
+                        $cmf = $this->response->addToVerbNode('set');
+                        $this->response->addChild($cmf, 'setSpec', $key);
+                        $this->response->addChild($cmf, 'setName', $val['name']);
+                    }
+                } else {
+                    $this->errors[] = new Exception('noSetHierarchy#1');
+                }
+            } catch (Exception $e) {
+                $this->errors[] = $e;
+            }
         } else {
             $this->errors[] = new Exception('noSetHierarchy');
         }
@@ -156,6 +171,8 @@ class Server {
         $metadataPrefix = isset($this->args['metadataPrefix']) ? $this->args['metadataPrefix'] : '';
         $from = isset($this->args['from']) ? $this->args['from'] : '';
         $until = isset($this->args['until']) ? $this->args['until'] : '';
+        $set = isset($this->args['set']) ? $this->args['set'] : null;
+
         if (isset($this->args['resumptionToken'])) {
             if (count($this->args) > 1) {
                 $this->errors[] = new Exception('badArgument');
@@ -199,15 +216,18 @@ class Server {
                 }
             }
             if (isset($this->args['set'])) {
-                $this->errors[] = new Exception('noSetHierarchy');
+                $ListSets = call_user_func($this->listSetsCallback);
+                if (!isset($ListSets[$this->args['set']])) {
+                    $this->errors[] = new Exception('noSetHierarchy');
+                }
             }
         }
         if (empty($this->errors)) {
             try {
-                if (!($records_count = call_user_func($this->listRecordsCallback, $metadataPrefix, $this->formatTimestamp($from), $this->formatTimestamp($until), true))) {
+                if (!($records_count = call_user_func($this->listRecordsCallback, $metadataPrefix, $this->formatTimestamp($from), $this->formatTimestamp($until), true, 0, 100, $set))) {
                     throw new Exception('noRecordsMatch');
                 }
-                $records = call_user_func($this->listRecordsCallback, $metadataPrefix, $this->formatTimestamp($from), $this->formatTimestamp($until), false, $deliveredRecords, $maxItems);
+                $records = call_user_func($this->listRecordsCallback, $metadataPrefix, $this->formatTimestamp($from), $this->formatTimestamp($until), false, $deliveredRecords, $maxItems, $set);
                 foreach ($records as $record) {
                     $cur_record = null;
                     if ($this->verb == 'ListRecords') { // for ListIdentifiers, only headers will be returned.

--- a/Configuration/Main.template.php
+++ b/Configuration/Main.template.php
@@ -56,6 +56,24 @@ $config = [
             'schema' => 'http://www.openarchives.org/OAI/2.0/oai_dc.xsd',
             'namespace' => 'http://www.openarchives.org/OAI/2.0/oai_dc/',
         ],
+        'mods' => [
+            'schema' => 'http://www.loc.gov/standards/mods/v3/mods-3-3.xsd',
+            'namespace' => 'http://www.loc.gov/mods/v3',
+        ],
+    ],
+
+    // Record Sets.
+    //
+    //
+    'ListSets' => [
+        10001 => [
+            'spec' => 10001,
+            'name' => 'Record Set One',
+        ],
+        10002 => [
+            'spec' => 10002,
+            'name' => 'Record Set Two',
+        ],
     ],
 
     // Directory containing the records

--- a/Resources/Stylesheet.xsl
+++ b/Resources/Stylesheet.xsl
@@ -148,6 +148,7 @@
     </xsl:choose>
   </xsl:variable>
   <xsl:variable name='identifier' select="/oai:OAI-PMH/oai:request/@identifier"/>
+  <xsl:variable name='set' select="/oai:OAI-PMH/oai:request/@set"/>
   <xsl:variable name='from' select="/oai:OAI-PMH/oai:request/@from"/>
   <xsl:variable name='until' select="/oai:OAI-PMH/oai:request/@until"/>
   <xsl:variable name='resumptionToken' select="/oai:OAI-PMH/oai:request/@resumptionToken"/>
@@ -178,6 +179,7 @@
           <li>&#187; <a class="link" href="?verb=ListMetadataFormats&amp;identifier={$identifier}">ListMetadataFormats (<em><xsl:value-of select="$identifier"/></em>)</a></li>
         </xsl:if>
         <xsl:if test="$metadataPrefix != ''">
+          <li>&#187; <a class="link" href="?verb=ListSets&amp;metadataPrefix={$metadataPrefix}">ListSets (<em><xsl:value-of select="$metadataPrefix"/></em>)</a></li>
           <li>&#187; <a class="link" href="?verb=ListIdentifiers&amp;metadataPrefix={$metadataPrefix}">ListIdentifiers (<em><xsl:value-of select="$metadataPrefix"/></em>)</a></li>
           <li>&#187; <a class="link" href="?verb=ListRecords&amp;metadataPrefix={$metadataPrefix}">ListRecords (<em><xsl:value-of select="$metadataPrefix"/></em>)</a></li>
           <xsl:if test="$identifier">
@@ -201,6 +203,8 @@
       <td class="value">
         <xsl:if test="oai:request/@verb">verb = <em><xsl:value-of select="$verb"/></em><br/></xsl:if>
         <xsl:if test="oai:request/@metadataPrefix">metadataPrefix = <em><xsl:value-of select="$metadataPrefix"/></em><br/></xsl:if>
+        <xsl:if test="oai:request/@listSets">listSets = <em><xsl:value-of select="$listSets"/></em><br/></xsl:if>
+        <xsl:if test="oai:request/@set">listSets = <em><xsl:value-of select="$set"/></em><br/></xsl:if>
         <xsl:if test="oai:request/@identifier">identifier = <em><xsl:value-of select="$identifier"/></em><br/></xsl:if>
         <xsl:if test="oai:request/@from">from = <em><xsl:value-of select="$from"/></em><br/></xsl:if>
         <xsl:if test="oai:request/@until">until = <em><xsl:value-of select="$until"/></em><br/></xsl:if>
@@ -221,6 +225,7 @@
         <div class="results">
           <xsl:apply-templates select="oai:Identify" />
           <xsl:apply-templates select="oai:ListMetadataFormats"/>
+          <xsl:apply-templates select="oai:ListSets"/>
           <xsl:apply-templates select="oai:ListIdentifiers"/>
           <xsl:apply-templates select="oai:ListRecords"/>
           <xsl:apply-templates select="oai:GetRecord"/>
@@ -293,6 +298,7 @@ Metadata Format Details
     <ul>
       <li>&#187; <a class="link" href="?verb=ListIdentifiers&amp;metadataPrefix={oai:metadataPrefix}">ListIdentifiers</a></li>
       <li>&#187; <a class="link" href="?verb=ListRecords&amp;metadataPrefix={oai:metadataPrefix}">ListRecords</a></li>
+      <li>&#187; <a class="link" href="?verb=ListSets&amp;metadataPrefix={oai:metadataPrefix}">ListSets</a></li>
       <xsl:if test="$identifier"><li>&#187; <a class="link" href="?verb=GetRecord&amp;metadataPrefix={oai:metadataPrefix}&amp;identifier={$identifier}">GetRecord</a></li></xsl:if>
     </ul>
     <table class="values">
@@ -302,6 +308,42 @@ Metadata Format Details
       <td class="value"><xsl:value-of select="oai:metadataNamespace"/></td></tr>
       <tr><td class="key">Schema</td>
       <td class="value"><a href="{oai:schema}"><xsl:value-of select="oai:schema"/></a></td></tr>
+    </table>
+  </li>
+</xsl:template>
+
+<!--
+ListSets
+-->
+<xsl:template match="oai:listSet">
+  <xsl:choose>
+    <xsl:when test="$metadataPrefix">
+      <p class="info">This is a list of data sets available for the record <em><xsl:value-of select="$metadataPrefix"/></em>.</p>
+    </xsl:when>
+    <xsl:otherwise>
+      <p class="info">This is a list of data sets available from this repository.</p>
+    </xsl:otherwise>
+  </xsl:choose>
+  <ol>
+    <xsl:apply-templates select="oai:listListSets"/>
+  </ol>
+</xsl:template>
+
+<!--
+Sets Format Details
+-->
+<xsl:template match="oai:set">
+  <li>
+    <h3>List Set <em><xsl:value-of select="oai:setName"/></em></h3>
+    <ul>
+      <xsl:if test="$metadataPrefix"><li>&#187; <a class="link" href="?verb=ListIdentifiers&amp;set={oai:setSpec}&amp;metadataPrefix={$metadataPrefix}">ListIdentifiers</a> </li></xsl:if>
+      <xsl:if test="$metadataPrefix"><li>&#187; <a class="link" href="?verb=ListRecords&amp;set={oai:setSpec}&amp;metadataPrefix={$metadataPrefix}">ListRecords</a></li></xsl:if>
+    </ul>
+    <table class="values">
+      <tr><td class="key">setSpec</td>
+      <td class="value"><xsl:value-of select="oai:setSpec"/></td></tr>
+      <tr><td class="key">setName</td>
+      <td class="value"><xsl:value-of select="oai:setName"/></td></tr>
     </table>
   </li>
 </xsl:template>

--- a/index.php
+++ b/index.php
@@ -30,10 +30,11 @@ require __DIR__.'/vendor/autoload.php';
 require __DIR__.'/Configuration/Main.php';
 
 // Get all available records and their respective status and timestamps
-$records = [];
-$deleted = [];
-$timestamps = [];
-$earliest = time();
+$records     = [];
+$setsrecords = [];
+$deleted     = [];
+$timestamps  = [];
+$earliest    = time();
 
 foreach ($config['metadataPrefix'] as $prefix => $uris) {
     $files = glob(rtrim($config['dataDirectory'], '/').'/'.$prefix.'/*.xml');
@@ -45,10 +46,36 @@ foreach ($config['metadataPrefix'] as $prefix => $uris) {
             $earliest = filemtime($file);
         }
     }
-    ksort($records[$prefix]);
-    reset($records[$prefix]);
-    ksort($timestamps[$prefix]);
-    reset($timestamps[$prefix]);
+    if (isset($records[$prefix])) {
+        ksort($records[$prefix]);
+        reset($records[$prefix]);
+        ksort($timestamps[$prefix]);
+        reset($timestamps[$prefix]);
+    }
+}
+
+// get all set records.
+foreach ($config['ListSets'] as $set => $setd) {
+    foreach ($config['metadataPrefix'] as $prefix => $uris) {
+        $path = rtrim($config['dataDirectory'], '/').'/sets/'.$set.'/'.$prefix.'/*.xml';
+        $files = glob(rtrim($config['dataDirectory'], '/').'/sets/'.$set.'/'.$prefix.'/*.xml');
+
+        foreach ($files as $file) {
+            $setsrecords[$set]['records'][$prefix][pathinfo($file, PATHINFO_FILENAME)] = $file;
+            $setsrecords[$set]['deleted'][$prefix][pathinfo($file, PATHINFO_FILENAME)] = !filesize($file);
+            $setsrecords[$set]['timestamps'][$prefix][filemtime($file)][] = pathinfo($file, PATHINFO_FILENAME);
+            if (filemtime($file) < $earliest) {
+                $earliest = filemtime($file);
+            }
+        }
+
+        if (isset($setsrecords[$set]['records'][$prefix])) {
+            ksort($setsrecords[$set]['records'][$prefix]);
+            reset($setsrecords[$set]['records'][$prefix]);
+            ksort($setsrecords[$set]['timestamps'][$prefix]);
+            reset($setsrecords[$set]['timestamps'][$prefix]);
+        }
+    }
 }
 
 // Get current base URL
@@ -88,7 +115,7 @@ $oai2 = new Server(
                 ];
             }
         },
-        'ListRecords' => function ($metadataPrefix, $from = null, $until = null, $count = false, $deliveredRecords = 0, $maxItems = 100) {
+        'ListRecords' => function ($metadataPrefix, $from = null, $until = null, $count = false, $deliveredRecords = 0, $maxItems = 100, $set = null) {
             global $records, $deleted, $timestamps;
             $resultSet = [];
             foreach ($timestamps[$metadataPrefix] as $timestamp => $identifiers) {
@@ -125,6 +152,26 @@ $oai2 = new Server(
                 }
             } else {
                 return $config['metadataPrefix'];
+            }
+        },
+        'ListSets' => function ($identifier = '') {
+            global $config, $records, $setsrecords;
+            if (!empty($identifier)) {
+                $listsets = [];
+                foreach ($setsrecords as $set => $records) {
+                    foreach ($records as $format => $record) {
+                        if (!empty($record[$identifier])) {
+                            $listsets[$set] = $config['ListSets'][$set];
+                        }
+                    }
+                }
+                if (!empty($listsets)) {
+                    return $listsets;
+                } else {
+                    throw new Exception('idDoesNotExist');
+                }
+            } else {
+                return $config['ListSets'];
             }
         }
     ],


### PR DESCRIPTION
Server.php to allow ListSets verb.

index.php with ListSets callback method, added set arg to ListRecords callback method.
When set is defined, listRecords method replaces plain record list with record list based on set - metadataPrefix scope. 

Edited Stylesheet.xsl to show ListSets button on ListMetadataFormats page.
Main.template.php contains new ListSets key with example sets.

Example of directory structure for MODS metadataPrefix:

original/records path:
`oaipmh_root/mods/123456789.xml`
`oaipmh_root/mods/234567891.xml`

sets with records path:
`oaipmh_root/sets/10001/mods/123456789.xml`
`oaipmh_root/sets/10001/mods/234567891.xml`

todo:
`ListSets` foreach loop should replace `metadataPrefix` when listsets are defined, and sets exist.
